### PR TITLE
FIX: sbl_logger.hh has been renamed

### DIFF
--- a/src/faodel-common/LoggingInterface.cpp
+++ b/src/faodel-common/LoggingInterface.cpp
@@ -11,7 +11,7 @@
 
 
 #if Faodel_LOGGINGINTERFACE_DISABLED==0 && Faodel_LOGGINGINTERFACE_USE_SBL==1
-#include <sbl/sbl_logger.hpp>
+#include <sbl/sbl_logger.hh>
 #endif
 
 
@@ -27,7 +27,7 @@
 
 #if Faodel_LOGGINGINTERFACE_USE_SBL==1
 
-#include <sbl/sbl_logger.hpp>
+#include <sbl/sbl_logger.hh>
 
 sbl::logger *faodel::LoggingInterface::sbl_logger=nullptr;
 

--- a/src/sbl/README_SBL.md
+++ b/src/sbl/README_SBL.md
@@ -205,7 +205,7 @@ Example:
     #include <thread>
     #include <map>
 
-    #include "sbl/sbl_logger.hpp"
+    #include "sbl/sbl_logger.hh"
     
     int main(int argc, char *argv[])
     {


### PR DESCRIPTION
Commit [1] renamed files. However, `sbl_logger.hh` was still being included
with its name prior renaming (i.e. `sbl_logger.hpp`).

[1] ff93eec910ad11074a3c88d112b2fd5cc1bccbfa