### PR TITLE
KELPIE: Update ObjectCapacities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.0)
 project( Faodel
   LANGUAGES CXX C
-  VERSION 1.1906.1
+  VERSION 1.1906.2
   )
 
 

--- a/src/kelpie/CMakeLists.txt
+++ b/src/kelpie/CMakeLists.txt
@@ -8,6 +8,7 @@ set( HEADERS_PUBLIC
      Kelpie.hh
      Key.hh
      common/KelpieInternal.hh
+     common/ObjectCapacities.hh
      common/Types.hh
      ioms/IomBase.hh
      ioms/IomRegistry.hh
@@ -42,6 +43,7 @@ set( SOURCES
      Kelpie.cpp
      Key.cpp
      common/KelpieInternal.cpp
+     common/ObjectCapacities.cpp
      common/OpArgsObjectAvailable.cpp
      common/Types.cpp
      core/KelpieCoreBase.cpp
@@ -126,7 +128,7 @@ install(TARGETS kelpie
 
 install( FILES Kelpie.hh Key.hh
   DESTINATION ${INCLUDE_INSTALL_DIR}/faodel/kelpie )
-install( FILES common/Types.hh common/KelpieInternal.hh
+install( FILES common/Types.hh common/KelpieInternal.hh common/ObjectCapacities.hh
   DESTINATION ${INCLUDE_INSTALL_DIR}/faodel/kelpie/common )
 install( FILES ioms/IomBase.hh ioms/IomRegistry.hh
   DESTINATION ${INCLUDE_INSTALL_DIR}/faodel/kelpie/ioms )

--- a/src/kelpie/common/ObjectCapacities.cpp
+++ b/src/kelpie/common/ObjectCapacities.cpp
@@ -1,0 +1,57 @@
+// Copyright 2021 National Technology & Engineering Solutions of Sandia,
+// LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+
+#include "kelpie/common/Types.hh"
+
+using namespace std;
+
+namespace kelpie {
+
+/// Append a key/capacity to this ObjectCapacities. Does NOT dedupe
+void ObjectCapacities::Append(const kelpie::Key &key, size_t capacity) {
+  keys.emplace_back(key);
+  capacities.emplace_back(capacity);
+}
+
+/// Append one ObjectCapacities to another. Does NOT dedupe
+void ObjectCapacities::Append(const ObjectCapacities &other) {
+  keys.insert(keys.end(), other.keys.begin(), other.keys.end());
+  capacities.insert(capacities.end(), other.capacities.begin(), other.capacities.end());
+}
+
+/// Merge two ObjectCapacities. If key exists, do not append from other
+void ObjectCapacities::Merge(const ObjectCapacities &other) {
+  for(int i = 0; i<other.keys.size(); i++) {
+    auto it = std::find(keys.begin(), keys.end(), other.keys[i]);
+    if(it == keys.end()) {
+      Append(other.keys[i], other.capacities[i]);
+    }
+  }
+}
+
+/// Locate a particular key
+int ObjectCapacities::FindIndex(const kelpie::Key &key) {
+  for(int i = 0; i<keys.size(); i++)
+    if(keys[i] == key) return i;
+  return -1;
+}
+
+
+
+/// Clear out all entries
+void ObjectCapacities::Wipe() {
+  keys.clear();
+  capacities.clear();
+}
+
+void ObjectCapacities::sstr(std::stringstream &ss, int depth, int indent) const {
+  ss<<string(indent,' ') << "ObjectCapacities Num: "<<keys.size()<<endl;
+  if(depth>=0) {
+    for(int i=0; i<keys.size();i++){
+      ss<<string(indent+2,' ')<<"["<<i<<"] "<<keys[i].str() << "\t" << capacities[i]<<endl;
+    }
+  }
+}
+
+} // namespace kelpie

--- a/src/kelpie/common/ObjectCapacities.hh
+++ b/src/kelpie/common/ObjectCapacities.hh
@@ -1,0 +1,49 @@
+// Copyright 2021 National Technology & Engineering Solutions of Sandia,
+// LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+
+#ifndef FAODEL_OBJECTCAPACITIES_HH
+#define FAODEL_OBJECTCAPACITIES_HH
+
+#include <vector>
+
+#include "faodel-common/InfoInterface.hh"
+
+namespace kelpie {
+
+class Key; //Forward reference
+
+class ObjectCapacities :
+        public faodel::InfoInterface {
+public:
+
+  //Note: These data structures are plain vectors because some callers need to update capacities first, then set the keys
+  std::vector <kelpie::Key> keys;
+  std::vector <size_t> capacities;
+
+  /// Append a ket/capacity to this ObjectCapacities. Does NOT dedupe
+  void Append(const kelpie::Key &key, size_t capacity);
+  void Append(const ObjectCapacities &other);
+
+  void Merge(const ObjectCapacities &other);
+
+  int FindIndex(const kelpie::Key &key);
+  void Wipe();
+
+  /// How many entries are here
+  size_t Size() {  return keys.size();  }
+
+  //Serialization hook
+  template<typename Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar & keys;
+    ar & capacities;
+  }
+
+  //InfoInterface function
+  void sstr(std::stringstream &ss, int depth, int indent) const override;
+};
+
+}  // namespace kelpie
+
+#endif //FAODEL_OBJECTCAPACITIES_HH

--- a/src/kelpie/common/Types.hh
+++ b/src/kelpie/common/Types.hh
@@ -1,4 +1,4 @@
-// Copyright 2018 National Technology & Engineering Solutions of Sandia, 
+// Copyright 2021 National Technology & Engineering Solutions of Sandia, 
 // LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS,  
 // the U.S. Government retains certain rights in this software. 
 
@@ -14,6 +14,7 @@
 #include "lunasa/DataObject.hh"
 
 #include "kelpie/Key.hh"
+#include "kelpie/common/ObjectCapacities.hh"
 
 #include <boost/serialization/vector.hpp> //For packing ObjectCapacities
 
@@ -138,22 +139,6 @@ struct PoolBehavior {
 };
 
 
-class ObjectCapacities {
-public:
-  std::vector<kelpie::Key> keys;
-  std::vector<size_t> capacities;
-
-  void Append(const ObjectCapacities &other) {
-    keys.insert(keys.end(), other.keys.begin(), other.keys.end());
-    capacities.insert(capacities.end(), other.capacities.begin(), other.capacities.end());
-  }
-  //Serialization hook
-  template <typename Archive>
-  void serialize(Archive &ar, const unsigned int version){
-    ar & keys;
-    ar & capacities;
-  }
-};
 
 
 


### PR DESCRIPTION
This PR refactors ObjectCapacities into separate files and adds a Size() method.

Bump the version to 1.1906.2 so it is easy for package builders (Spack) to reference this update.
